### PR TITLE
Use explicit IP whitelist instead of automatic IP whitelist

### DIFF
--- a/hack/docker/mysql/5.7.25/on-start.sh
+++ b/hack/docker/mysql/5.7.25/on-start.sh
@@ -65,6 +65,16 @@ declare -i srv_id=$(hostname | sed -e "s/${BASE_NAME}-//g")
 
 export cur_addr="${cur_host}:33060"
 
+# Get ip_whitelist
+# https://dev.mysql.com/doc/refman/5.7/en/group-replication-options.html#sysvar_group_replication_ip_whitelist
+# https://dev.mysql.com/doc/refman/5.7/en/group-replication-ip-address-whitelisting.html
+#
+# Command $(hostname -I) returns a space separated IP list. We need only the first one.
+myips=$(hostname -I)
+first=${myips%% *}
+# Now use this IP with CIDR notation
+export whitelist="${first}/16"
+
 # the mysqld configurations have take by following
 # 01. official doc: https://dev.mysql.com/doc/refman/5.7/en/group-replication-configuring-instances.html
 # 02. digitalocean doc: https://www.digitalocean.com/community/tutorials/how-to-configure-mysql-group-replication-on-ubuntu-16-04
@@ -90,7 +100,7 @@ loose-group_replication_recovery_use_ssl = 1
 
 # Shared replication group configuration
 loose-group_replication_group_name = "${GROUP_NAME}"
-#loose-group_replication_ip_whitelist = "${hosts}"
+loose-group_replication_ip_whitelist = "${whitelist}"
 loose-group_replication_group_seeds = "${seeds}"
 
 # Single or Multi-primary mode? Uncomment these two lines


### PR DESCRIPTION
xref: https://github.com/kubedb/project/issues/529

The AUTOMATIC whitelist generated only works for single node cluster.

- https://dev.mysql.com/doc/refman/5.7/en/group-replication-options.html#sysvar_group_replication_ip_whitelist
- https://dev.mysql.com/doc/refman/5.7/en/group-replication-ip-address-whitelisting.html

resolution: set whitelist to `pod_ip/16`

- https://unix.stackexchange.com/a/201744/42136

```
# use hostname to detect pod ip inside the mysql docker image.
$ hostname -I
192.168.0.100 172.17.0.1 192.168.99.1 

$ myips=$(hostname -I)
$ first=${myips%% *}
$ echo $first
192.168.0.100
```