### PR TITLE
Update github.com/apache/thrift v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 
 replace (
 	cloud.google.com/go => cloud.google.com/go v0.38.0
-	git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+	git.apache.org/thrift.git => github.com/apache/thrift v0.12.1-0.20181231034149-e2109b914cef 
 	github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v32.5.0+incompatible
 	github.com/Azure/go-ansiterm => github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.0.0+incompatible


### PR DESCRIPTION
github.com/apache/thrift v0.12.0 is vulnerable so suggesting to upgrade the version to a secured one. You can check module vulnerability here :
https://search.gocenter.io/github.com~2Fapache~2Fthrift/info?version=v0.12.0

CVE-2019-0205 
n Apache Thrift all versions up to and including 0.12.0, a server or client may run into an endless loop when feed with specific input data. Because the issue had already been partially fixed in version 0.11.0, depending on the installed version it affects only certain language bindings