### PR TITLE
Prepare for release v0.7.0-beta.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20200521103120-92080446e04d
 	kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226
 	kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
-	kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903230240-76ac9bc0603a
+	kubedb.dev/apimachinery v0.14.0-beta.2
 	stash.appscode.dev/apimachinery v0.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1256,8 +1256,8 @@ kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c h1:aV6O9NbDpnFVra/D8c7b7T
 kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c/go.mod h1:XYWZkfQquD09Mn+O7piHS+SEPq9oFV1Wy2WZ9DA+oeA=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0 h1:rEOWPdiRYShJdJxX0sf76JYWOMzPQH4v8ByT+DRCmVY=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0/go.mod h1:9hUftUcjvzDSiO5LIbe2U8Naz4tyS9Ndf1LRzsytMzs=
-kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903230240-76ac9bc0603a h1:o2j1q9T0QLCiN1N+n8FVHYnL6Cic1ti+cO3U0dt9wX8=
-kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903230240-76ac9bc0603a/go.mod h1:WQ/oXfTfXNRfz6JvRBIoHwi3Dg4eumKnXu5WXquGF0Y=
+kubedb.dev/apimachinery v0.14.0-beta.2 h1:Ws+DYzQmESOP7mwaaeXcDjWae9joiG/Xi8yYoSBnLD0=
+kubedb.dev/apimachinery v0.14.0-beta.2/go.mod h1:WQ/oXfTfXNRfz6JvRBIoHwi3Dg4eumKnXu5WXquGF0Y=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1077,7 +1077,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903230240-76ac9bc0603a
+# kubedb.dev/apimachinery v0.14.0-beta.2
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.09.04-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/4
Signed-off-by: 1gtm <1gtm@appscode.com>