### PR TITLE
Prepare for release v0.7.0-beta.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20200922210707-59bab27e5d41
 	kmodules.xyz/offshoot-api v0.0.0-20200922211229-36acc531abab
 	kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
-	kubedb.dev/apimachinery v0.14.0-beta.4.0.20201026155152-6ce39fbe7b06
+	kubedb.dev/apimachinery v0.14.0-beta.5
 	stash.appscode.dev/apimachinery v0.11.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1499,8 +1499,8 @@ kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e h1:NASVP0dOE5Zdlq+3Op7Fh2
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e/go.mod h1:AZ58K5hrxkkNPf8tM+UWeZjtNG3/mn192nKcUyC93F8=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de h1:uWgv78OoOWx9eQdu6SEkPopvbpnL8WxZEMNd3/Oye2w=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de/go.mod h1:5A8s2nvrNAZGrt0OlsiiuZIik3xWyKW6+ZSwgljIm78=
-kubedb.dev/apimachinery v0.14.0-beta.4.0.20201026155152-6ce39fbe7b06 h1:zfDtfomHBn0b6RPUMVniqAPO0Ie2T1gHmKaHYP/LiLA=
-kubedb.dev/apimachinery v0.14.0-beta.4.0.20201026155152-6ce39fbe7b06/go.mod h1:3/Dy8tn3ScoG3MnPKa8Ac0CDBqOuLo2r01BI3GVHgjM=
+kubedb.dev/apimachinery v0.14.0-beta.5 h1:CwLMgJCHrztN+ouaYl7PDZS4UB1aybLVifvsGCYm9Ms=
+kubedb.dev/apimachinery v0.14.0-beta.5/go.mod h1:3/Dy8tn3ScoG3MnPKa8Ac0CDBqOuLo2r01BI3GVHgjM=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -77,7 +77,6 @@ const (
 	ElasticsearchStatusYellow                    = "yellow"
 	ElasticsearchStatusRed                       = "red"
 
-	// =========================== MongoDB Constants ============================
 	// Ref:
 	//	- https://www.elastic.co/guide/en/elasticsearch/reference/7.6/heap-size.html#heap-size
 	//	- no more than 50% of your physical RAM
@@ -88,12 +87,19 @@ const (
 	// 128MB
 	ElasticsearchMinHeapSize = 128 * 1024 * 1024
 
-	MongoDBShardPort           = 27017
-	MongoDBConfigdbPort        = 27017
-	MongoDBMongosPort          = 27017
-	MongoDBKeyFileSecretSuffix = "key"
-	MongoDBRootUsername        = "root"
-	MongoDBCustomConfigFile    = "mongod.conf"
+	// =========================== Memcached Constants ============================
+	MemcachedDatabasePortName       = "db"
+	MemcachedPrimaryServicePortName = "primary"
+	MemcachedDatabasePort           = 11211
+
+	// =========================== MongoDB Constants ============================
+
+	MongoDBDatabasePortName       = "db"
+	MongoDBPrimaryServicePortName = "primary"
+	MongoDBDatabasePort           = 27017
+	MongoDBKeyFileSecretSuffix    = "key"
+	MongoDBRootUsername           = "root"
+	MongoDBCustomConfigFile       = "mongod.conf"
 
 	// =========================== MySQL Constants ============================
 	MySQLMetricsExporterConfigSecretSuffix = "metrics-exporter-config"
@@ -151,23 +157,33 @@ const (
 	LabelProxySQLName        = ProxySQLKey + "/name"
 	LabelProxySQLLoadBalance = ProxySQLKey + "/load-balance"
 
-	ProxySQLMySQLNodePort         = 6033
-	ProxySQLAdminPort             = 6032
-	ProxySQLAdminPortName         = "admin"
-	ProxySQLDataMountPath         = "/var/lib/proxysql"
-	ProxySQLCustomConfigMountPath = "/etc/custom-config"
+	ProxySQLDatabasePort           = 6033
+	ProxySQLDatabasePortName       = "db"
+	ProxySQLPrimaryServicePortName = "db"
+	ProxySQLAdminPort              = 6032
+	ProxySQLAdminPortName          = "admin"
+	ProxySQLDataMountPath          = "/var/lib/proxysql"
+	ProxySQLCustomConfigMountPath  = "/etc/custom-config"
 
 	// =========================== Redis Constants ============================
-	RedisShardKey   = RedisKey + "/shard"
-	RedisNodePort   = 6379
-	RedisGossipPort = 16379
+	RedisShardKey               = RedisKey + "/shard"
+	RedisDatabasePortName       = "db"
+	RedisPrimaryServicePortName = "primary"
+	RedisDatabasePort           = 6379
+	RedisGossipPortName         = "gossip"
+	RedisGossipPort             = 16379
 
 	RedisKeyFileSecretSuffix = "key"
 	RedisPEMSecretSuffix     = "pem"
 	RedisRootUsername        = "root"
 
 	// =========================== PgBouncer Constants ============================
-	PgBouncerUpstreamServerCA = "upstream-server-ca.crt"
+	PgBouncerUpstreamServerCA       = "upstream-server-ca.crt"
+	PgBouncerDatabasePortName       = "db"
+	PgBouncerPrimaryServicePortName = "primary"
+	PgBouncerDatabasePort           = 5432
+	PgBouncerConfigFile             = "pgbouncer.ini"
+	PgBouncerAdminUsername          = "kubedb"
 )
 
 // List of possible condition types for a KubeDB object

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -243,7 +243,7 @@ func (m MongoDB) ShardHosts(nodeNum int32) []string {
 	}
 	hosts := make([]string, m.Spec.ShardTopology.Shard.Replicas)
 	for i := 0; i < int(m.Spec.ShardTopology.Shard.Replicas); i++ {
-		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ShardNodeName(nodeNum), i, m.GoverningServiceName(m.ShardNodeName(nodeNum)), m.Namespace, MongoDBShardPort)
+		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ShardNodeName(nodeNum), i, m.GoverningServiceName(m.ShardNodeName(nodeNum)), m.Namespace, MongoDBDatabasePort)
 	}
 	return hosts
 }
@@ -265,7 +265,7 @@ func (m MongoDB) ConfigSvrHosts() []string {
 
 	hosts := make([]string, m.Spec.ShardTopology.ConfigServer.Replicas)
 	for i := 0; i < int(m.Spec.ShardTopology.ConfigServer.Replicas); i++ {
-		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ConfigSvrNodeName(), i, m.GoverningServiceName(m.ConfigSvrNodeName()), m.Namespace, MongoDBShardPort)
+		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ConfigSvrNodeName(), i, m.GoverningServiceName(m.ConfigSvrNodeName()), m.Namespace, MongoDBDatabasePort)
 	}
 	return hosts
 }
@@ -277,7 +277,7 @@ func (m MongoDB) MongosHosts() []string {
 
 	hosts := make([]string, m.Spec.ShardTopology.Mongos.Replicas)
 	for i := 0; i < int(m.Spec.ShardTopology.Mongos.Replicas); i++ {
-		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.MongosNodeName(), i, m.GoverningServiceName(m.MongosNodeName()), m.Namespace, MongoDBShardPort)
+		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.MongosNodeName(), i, m.GoverningServiceName(m.MongosNodeName()), m.Namespace, MongoDBDatabasePort)
 	}
 	return hosts
 }

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/pgbouncer_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/pgbouncer_helpers.go
@@ -83,6 +83,14 @@ func (p PgBouncer) GoverningServiceName() string {
 	return meta_util.NameWithSuffix(p.ServiceName(), "pods")
 }
 
+func (p PgBouncer) AuthSecretName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "auth")
+}
+
+func (p PgBouncer) ConfigSecretName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "config")
+}
+
 type pgbouncerApp struct {
 	*PgBouncer
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1141,7 +1141,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.4.0.20201026155152-6ce39fbe7b06
+# kubedb.dev/apimachinery v0.14.0-beta.5
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.26-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/16
Signed-off-by: 1gtm <1gtm@appscode.com>