### PR TITLE
Prepare for release v0.9.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20201105074044-be7a1044891a
 	kmodules.xyz/offshoot-api v0.0.0-20201105074700-8675f5f686f2
 	kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
-	kubedb.dev/apimachinery v0.15.3-0.20210103060716-e4cb7ef912f3
+	kubedb.dev/apimachinery v0.16.0-rc.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1425,8 +1425,8 @@ kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8 h1:UJb5lHQVFKbmlgmRLq5IWJ
 kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8/go.mod h1:2eN8X5Wq7/AAgE5AWMAX8T0lE51HZiYEldG2RQuouX4=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6 h1:9+EIwxUrXrM8QD9rC1Fg+6CQK0vPniFO3ClaKih010M=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
-kubedb.dev/apimachinery v0.15.3-0.20210103060716-e4cb7ef912f3 h1:Blfj3NXah4c2Kjge6HdWlzirXg0Xab1TBJjaZU9txwc=
-kubedb.dev/apimachinery v0.15.3-0.20210103060716-e4cb7ef912f3/go.mod h1:jfH9wMWLd+rgDagKSFegJ1OJE8FU3V3rc+0dBCdi1sk=
+kubedb.dev/apimachinery v0.16.0-rc.0 h1:HDNs92BxrzNXRowZOh5x1M5acWpxpxpVHH7V4LZpjR4=
+kubedb.dev/apimachinery v0.16.0-rc.0/go.mod h1:jfH9wMWLd+rgDagKSFegJ1OJE8FU3V3rc+0dBCdi1sk=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1065,7 +1065,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.15.3-0.20210103060716-e4cb7ef912f3
+# kubedb.dev/apimachinery v0.16.0-rc.0
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.01.02-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/28
Signed-off-by: 1gtm <1gtm@appscode.com>